### PR TITLE
docs: relicense to MIT and refresh project docs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,4 @@
-name: Go
+name: CI
 
 on:
   push:
@@ -10,21 +10,28 @@ jobs:
 
   test:
     strategy:
+      fail-fast: false
       matrix:
-        go_version: [ '1.14', '1.15', '1.16', '1.17' ]
+        # 1.18 is the module floor (go.mod); oldstable/stable track the two
+        # most recent Go releases.
+        go-version: [ '1.18', 'oldstable', 'stable' ]
         os: [ 'ubuntu-latest', 'windows-latest', 'macOS-latest' ]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - name: Use GO ${{ matrix.go_version }}
-        uses: actions/setup-go@v2
+      - name: Use Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go_version }}
+          go-version: ${{ matrix.go-version }}
 
-      - name: Test GO ${{ matrix.go_version }}
+      - name: Test
         run: go test ./... -race -coverprofile=coverage.txt -covermode=atomic
 
-      - name: Upload to codecov
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.go_version == '1.17' }}
-        run: bash <(curl -s https://codecov.io/bash)
+      - name: Upload coverage to Codecov
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.go-version == 'stable' }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.txt
+          fail_ci_if_error: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+While the major version is `0`, the public API may change in any release.
+
+## [Unreleased]
+
+### Added
+
+- `CONTRIBUTING.md` describing setup, the test/lint workflow, code style, and the
+  commit/PR/release process.
+- This `CHANGELOG.md`.
+
+### Changed
+
+- Relicensed the project from the Apache License 2.0 to the MIT License.
+- Reworked `README.md`: status badges, a tag reference table, the supported-type
+  list, an explicit default-precedence rule (CLI flag > `envVar` > `value` > zero
+  value), and a runnable example.
+
+## [0.0.3] - 2022-11-08
+
+### Added
+
+- `uint` and `uint64` field types.
+
+### Changed
+
+- Converted the project to a Go module (`module github.com/memclutter/confparse`,
+  `go 1.18`).
+- Replaced Travis CI with a GitHub Actions workflow running `go test ./... -race`
+  across a Go version matrix (1.14–1.17) on Linux, macOS, and Windows, and
+  uploading coverage to Codecov.
+- Reworked the test suite into table-driven cases at 100% coverage, including the
+  default-value error paths for every supported type.
+
+## [0.0.2] - 2018-10-08
+
+### Added
+
+- `int64` field type.
+
+## [0.0.1] - 2018-09-25
+
+First release of `confparse` — a declarative command-line argument parser for Go.
+
+### Added
+
+- `Parse(container interface{}) error`, which reflects over a pointer-to-struct
+  and registers each field as a standard-library `flag`.
+- Struct tags `name` (flag name), `value` (string default), `usage` (help text),
+  and `envVar` (environment-variable fallback for the default).
+- Supported field types: `string`, `int`, `bool`, and `time.Duration`.
+- Environment extension: when a field's `envVar` variable is set and non-empty,
+  its value becomes the field's default.
+
+[Unreleased]: https://github.com/memclutter/confparse/compare/v0.0.3...HEAD
+[0.0.3]: https://github.com/memclutter/confparse/compare/v0.0.2...v0.0.3
+[0.0.2]: https://github.com/memclutter/confparse/compare/v0.0.1...v0.0.2
+[0.0.1]: https://github.com/memclutter/confparse/releases/tag/v0.0.1
+</content>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ While the major version is `0`, the public API may change in any release.
   commit/PR/release process.
 - This `CHANGELOG.md`.
 
+### Fixed
+
+- CI is green again. The GitHub Actions workflow tested Go 1.14–1.17, which have
+  no `darwin/arm64` builds and so failed to install on the now-Apple-Silicon
+  `macOS-latest` runners, cancelling the whole matrix. The workflow now tests the
+  module's real floor (`1.18`) plus the two latest Go releases, sets
+  `fail-fast: false`, and upgrades to `actions/checkout@v4`,
+  `actions/setup-go@v5`, and `codecov/codecov-action@v5`.
+
 ### Changed
 
 - Relicensed the project from the Apache License 2.0 to the MIT License.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,89 @@
+# Contributing
+
+Thanks for your interest in improving `confparse`. This document describes how to
+set up the project, the conventions the codebase follows, and how to get a change
+merged.
+
+## Prerequisites
+
+- Go 1.18 or newer (the module targets `go 1.18`).
+- That is all — `confparse` has no runtime dependencies beyond the standard
+  library, and the test suite needs no external services.
+
+## Getting started
+
+```bash
+git clone https://github.com/memclutter/confparse.git
+cd confparse
+go mod download
+go test ./...
+```
+
+`confparse` is a library, not a binary: there is nothing to run on its own. The
+quickest way to exercise a change is to add or adjust a case in `parse_test.go`.
+
+## Development workflow
+
+- Branch off `main` with a short-lived topic branch; keep one logical change per
+  pull request.
+- Run the checks below before pushing; CI must be green before review.
+
+```bash
+go build ./...                              # compiles
+go test ./... -race -coverprofile=cover.out # runs the suite with the race detector
+gofmt -l .                                  # must print nothing (formatting)
+```
+
+CI (`.github/workflows/go.yml`) runs `go test ./... -race` across a matrix of Go
+versions and operating systems on every push and pull request, and uploads
+coverage to Codecov. The suite is kept at 100% coverage — keep it there.
+
+## Code style
+
+- Format with `gofmt` / `goimports`; do not hand-format.
+- Keep the public surface minimal: the package exposes a single function,
+  `Parse(container interface{}) error`. Treat it and the existing struct-tag
+  names (`name`, `value`, `usage`, `envVar`) as a stability contract.
+- Wrap errors with context rather than returning bare errors where it adds
+  information.
+- Prefer table-driven tests; every supported type and error path has a row in
+  `parse_test.go` — add one for anything you change.
+
+## Adding a supported type
+
+Supported field types are a contract. When adding one:
+
+1. Add a `case *T:` to the type switch in `declareFlag` (`parse.go`), converting
+   the `value` string into `T` and registering the matching `flag.TVar`.
+2. Add a conversion helper if the type needs one, mirroring the existing
+   `toInt` / `toUint` / `toTimeDuration` helpers (return the conversion error).
+3. Add success and error-path rows to `parse_test.go`, and document the type in
+   `README.md`.
+
+## Commit messages
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat(parse): support float64 fields
+fix(parse): return error on invalid uint default
+docs(readme): document default precedence
+```
+
+Use `feat` / `fix` / `docs` / `refactor` / `test` / `chore` as appropriate; mark
+breaking changes with a `!` or a `BREAKING CHANGE:` footer. Adding a type or tag
+extends the public contract — call it out in the message.
+
+## Pull requests
+
+- Describe what changes and why; link any related issue.
+- Keep the diff focused and the history readable.
+- Update `README.md` and `CHANGELOG.md` (under `## [Unreleased]`) when your change
+  affects behaviour users can see.
+
+## Releases
+
+Releases follow [Semantic Versioning](https://semver.org/). While the major
+version is `0`, the public API may change in any release. Maintainers cut releases
+by tagging `vMAJOR.MINOR.PATCH` and publishing notes built from the changelog.
+</content>

--- a/LICENSE
+++ b/LICENSE
@@ -1,201 +1,22 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+MIT License
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Copyright (c) 2026 Memory Clutter
 
-   1. Definitions.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</content>

--- a/README.md
+++ b/README.md
@@ -1,15 +1,40 @@
-# Confparse
+# confparse
 
-[![Language Golang](https://img.shields.io/badge/language-golang-blue.svg)](https://img.shields.io/badge/language-golang-blue.svg)
-[![Hex.pm](https://img.shields.io/hexpm/l/plug.svg)](https://github.com/memclutter/confparse)
+> Declarative command-line argument parser for Go — describe your configuration
+> as a tagged struct and call `confparse.Parse`; fields become CLI flags, with
+> per-field defaults and optional environment-variable fallbacks.
+
+[![Release](https://img.shields.io/github/v/release/memclutter/confparse?sort=semver)](https://github.com/memclutter/confparse/releases)
+[![Go Reference](https://pkg.go.dev/badge/github.com/memclutter/confparse.svg)](https://pkg.go.dev/github.com/memclutter/confparse)
+[![Go Report Card](https://goreportcard.com/badge/github.com/memclutter/confparse)](https://goreportcard.com/report/github.com/memclutter/confparse)
+[![Go version](https://img.shields.io/github/go-mod/go-version/memclutter/confparse)](go.mod)
+[![CI](https://github.com/memclutter/confparse/actions/workflows/go.yml/badge.svg)](https://github.com/memclutter/confparse/actions/workflows/go.yml)
 [![codecov](https://codecov.io/gh/memclutter/confparse/branch/main/graph/badge.svg?token=G0U5MRSSFZ)](https://codecov.io/gh/memclutter/confparse)
-[![Go](https://github.com/memclutter/confparse/actions/workflows/go.yml/badge.svg)](https://github.com/memclutter/confparse/actions/workflows/go.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-Declarative command line argument parser for golang projects. 
+`confparse` turns a configuration struct into command-line flags without the
+boilerplate of wiring the standard `flag` package by hand. You declare each
+option as a struct field with tags, call `Parse`, and read the populated struct.
+
+- **Declarative** — one struct describes the whole CLI surface.
+- **Standard `flag` under the hood** — flags, defaults, and `-help` behave exactly
+  as Go developers expect.
+- **Environment fallbacks** — any field can take its default from an environment
+  variable via a single tag.
+- **Zero runtime dependencies** — only the Go standard library.
+
+## Contents
+
+- [Install](#install)
+- [Usage](#usage)
+- [Struct tags](#struct-tags)
+- [Supported types](#supported-types)
+- [Defaults and precedence](#defaults-and-precedence)
+- [Example](#example)
+- [Contributing](#contributing)
+- [License](#license)
 
 ## Install
-
-Install go module
 
 ```shell
 go get github.com/memclutter/confparse
@@ -17,36 +42,63 @@ go get github.com/memclutter/confparse
 
 ## Usage
 
-Use `struct` tags to declare command-line arguments. 
+Declare command-line arguments with `struct` tags and pass a pointer to `Parse`:
 
 ```go
-// ...
-
 type Config struct {
-	Argument1 string `name:"arg1" usage:"Argument 1 help text"`
-	Timeout time.Duration `name:"timeout" value:"200ms" usage:"Timeout argument"`
+	Addr    string        `name:"addr" value:":8000" usage:"Listen and serve address"`
+	Timeout time.Duration `name:"timeout" value:"200ms" usage:"Request timeout"`
 }
 
-// ...
+cfg := &Config{}
+if err := confparse.Parse(cfg); err != nil {
+	log.Fatalf("parse configuration: %s", err)
+}
 ```
 
-## Supported Types
+`Parse` reads the tags off each field, registers a flag bound to that field, and
+then parses `os.Args`. It returns an error only when a field's default `value`
+cannot be parsed into the field's type.
 
-Different types of arguments are supported:
+## Struct tags
 
-- `string` by default any arguments is a string
-- `int` like `1`, `2`, `300`, `-23` etc
-- `time.Duration` for time interval argument, like `10s`, `500ms`, `20us` etc
-- `bool` for boolean argument
+| Tag      | Meaning                                                          |
+|----------|------------------------------------------------------------------|
+| `name`   | Flag name — `name:"addr"` registers `-addr`.                     |
+| `value`  | Default value, as a string, parsed into the field's type.       |
+| `usage`  | Help text shown in the standard `flag` usage output.            |
+| `envVar` | Environment variable to source the default from (see below).    |
 
-## Environment Extension
+A field with no recognised tags, or of an unsupported type, is simply skipped.
 
-Use special struct tag `envVar` if you application read configuration from environment variables. 
-Set environment variable name in `envVar` and confparse read value from there.
+## Supported types
+
+```text
+string   int   int64   uint   uint64   bool   time.Duration
+```
+
+- `string` — used as-is (the default field type).
+- `int`, `int64`, `uint`, `uint64` — parsed with `strconv`; e.g. `1`, `300`, `-23`
+  (signed types only).
+- `bool` — `true` / `false`.
+- `time.Duration` — Go duration syntax, e.g. `10s`, `500ms`, `20us`.
+
+## Defaults and precedence
+
+For each field the effective default is resolved before the flag is parsed, then
+the CLI flag (if present) wins:
+
+```text
+CLI flag  >  environment variable (envVar)  >  value default  >  zero value
+```
+
+Set `envVar` to read a default from the environment. When that variable is set
+and non-empty, its value replaces the `value` default; an empty or unset variable
+is ignored. A passed `-name` flag always overrides whatever default was chosen.
 
 ## Example
 
-The following is an example of defining a configuration for a simple web server
+A small web server configured entirely through `confparse`:
 
 ```go
 package main
@@ -59,7 +111,7 @@ import (
 )
 
 type Config struct {
-	Addr string `name:"addr" value:":8000" usage:"Listen and serve address"`
+	Addr   string `name:"addr" value:":8000" usage:"Listen and serve address"`
 	ApiKey string `name:"apiKey" envVar:"API_KEY" usage:"API key"`
 }
 
@@ -70,13 +122,26 @@ func main() {
 		log.Fatalf("Error parse configuration: %s", err)
 	}
 
-        log.Printf("API Key: %s", appConfig.ApiKey)
-
+	log.Printf("API Key: %s", appConfig.ApiKey)
 	log.Printf("Listen and serve on %s", appConfig.Addr)
 	if err := http.ListenAndServe(appConfig.Addr, nil); err != nil {
 		log.Fatalf("Listen and serve error: %s", err)
 	}
 }
-
 ```
 
+```shell
+go run . -addr :9000          # -addr overrides the default
+API_KEY=secret go run .       # apiKey comes from the environment
+```
+
+## Contributing
+
+Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for setup,
+coding conventions, and the commit/PR process. Changes are recorded in
+[CHANGELOG.md](CHANGELOG.md).
+
+## License
+
+Released under the [MIT License](LICENSE).
+</content>


### PR DESCRIPTION
Post-import housekeeping for confparse.

## What
- **Relicense** from Apache-2.0 to **MIT**, for consistency with the other
  `memclutter` projects (e.g. nocodb-migrator).
- **README** rework: status badges (release, Go reference, Go report card, Go
  version, CI, codecov, license), a struct-tag reference table, the full
  supported-type list (`string`, `int`, `int64`, `uint`, `uint64`, `bool`,
  `time.Duration`), an explicit default-precedence rule (CLI flag > `envVar` >
  `value` > zero value), and a runnable example.
- **Add `CONTRIBUTING.md`** — setup, test/lint workflow, code style, how to add a
  supported type, commit/PR/release process.
- **Add `CHANGELOG.md`** — Keep a Changelog format, reconstructed from the
  v0.0.1–v0.0.3 git history, with the relicense + docs under `[Unreleased]`.

## Why
The repo was imported into the personal OS; this brings its docs and licensing in
line with the other projects. No source/behaviour changes — `go test ./...` stays
green at 100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)